### PR TITLE
Add endpoint to fetch simulation by protocol

### DIFF
--- a/src/main/java/br/com/smartinvest/smart_invest_api/controller/SimulacaoController.java
+++ b/src/main/java/br/com/smartinvest/smart_invest_api/controller/SimulacaoController.java
@@ -3,6 +3,7 @@ package br.com.smartinvest.smart_invest_api.controller;
 
 import br.com.smartinvest.smart_invest_api.DTO.request.SimulacaoRequestDTO;
 import br.com.smartinvest.smart_invest_api.DTO.response.BaseResponse;
+import br.com.smartinvest.smart_invest_api.DTO.response.SimulacaoResponseDTO;
 import br.com.smartinvest.smart_invest_api.service.SimulacaoService;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.HttpStatus;
@@ -10,9 +11,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/simulacao")
+@RequestMapping("/api/simulacao")
 public class SimulacaoController {
     private final SimulacaoService simulacaoService;
+    private Object simulacaoDTO;
 
     public SimulacaoController(SimulacaoService simulacaoService) {
         this.simulacaoService = simulacaoService;
@@ -40,6 +42,24 @@ public class SimulacaoController {
         );
     }
 
+    @GetMapping("/{protocolo}")
+    @Operation(summary = "Recuperar simulação por protocolo")
+    public ResponseEntity<BaseResponse> getSimulacaoByProtocolo(@PathVariable String protocolo) {
+        SimulacaoResponseDTO simulacaoDTO = simulacaoService.buscarPorProtocolo(protocolo);
 
+        // Tratamento para caso a simulação não seja encontrada
+        if (simulacaoDTO == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(BaseResponse.builder()
+                    .message("Simulação não encontrada para o protocolo: " + protocolo)
+                    .status(HttpStatus.NOT_FOUND)
+                    .data(null)
+                    .build());
+        }
 
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.builder()
+                .message("Simulação Encontrada!")
+                .status(HttpStatus.OK)
+                .data(simulacaoDTO)
+                .build());
+    }
 }

--- a/src/main/java/br/com/smartinvest/smart_invest_api/service/SimulacaoService.java
+++ b/src/main/java/br/com/smartinvest/smart_invest_api/service/SimulacaoService.java
@@ -62,4 +62,13 @@ public class SimulacaoService {
         simulacaoRepository.save(simulacao);
         return SimulacaoMapper.toSimulacaoResponseDTO(simulacao);
     }
+
+    public SimulacaoResponseDTO buscarPorProtocolo(String protocolo) {
+        //Chamar repositório para buscar no banco de dados
+        //Se a entidade não for encontrada, retornar 'null' para que o controller possa tratar
+        //Mapear a entidade para DTO (resposta)
+        return null;
+
+
+    }
 }


### PR DESCRIPTION
Introduces a GET /api/simulacao/{protocolo} endpoint in SimulacaoController to retrieve simulation data by protocol. Adds buscarPorProtocolo method stub in SimulacaoService for future implementation.